### PR TITLE
Add comment sentiment to page

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -33,6 +33,11 @@
       <artifactId>appengine-api-1.0-sdk</artifactId>
       <version>1.9.59</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-language</artifactId>
+      <version>1.55.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -1,0 +1,80 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.data;
+
+/** Comment data class */
+public class Comment {
+
+  /* Comment text */
+  private String commentText;
+
+  /* Comment sentiment */
+  private boolean sentimentScoreFlag;
+
+  private float sentimentScore;
+
+  /**
+   * Constructs a comment object with given text
+   *
+   * @param commentText the comment text
+   */
+  public Comment(String commentText) {
+    this.commentText = commentText;
+    this.sentimentScoreFlag = false;
+  }
+
+  /** Getter and setter for commentText */
+  public String getCommentText() {
+    return commentText;
+  }
+
+  public void setCommentText(String commentText) {
+    this.commentText = commentText;
+  }
+
+  /**
+   * Retreives comment sentiment -- provided hasSentimentScore is true -- otherwise the result is
+   * undefined.
+   *
+   * @return sentiment score provided hasSentimentScore is true.
+   */
+  public float getSentimentScore() {
+    return sentimentScore;
+  }
+
+  /**
+   * Sets comment sentiment score, setting hasSentimentScore as true if not already set.
+   *
+   * @param sentimentScore the score in the range [-1.0 to 1.0].
+   */
+  public void setSentimentScore(float sentimentScore) {
+    this.sentimentScore = sentimentScore;
+    this.sentimentScoreFlag = true;
+  }
+
+  /**
+   * Test if comment has sentiment score
+   *
+   * @return whether the comment has a sentiment score.
+   */
+  public boolean hasSentimentScore() {
+    return sentimentScoreFlag;
+  }
+
+  /** Deletes the comment's sentiment score */
+  public void deleteSentimentScore() {
+    sentimentScoreFlag = false;
+  }
+}

--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -14,6 +14,8 @@
 
 package com.google.sps.data;
 
+import com.google.appengine.api.datastore.Entity;
+
 /** Comment data class */
 public class Comment {
 
@@ -33,6 +35,15 @@ public class Comment {
   public Comment(String commentText) {
     this.commentText = commentText;
     this.sentimentScoreFlag = false;
+  }
+
+  /**
+   * Constructs a comment object by unmarshalling an entity
+   *
+   * @param entity the entity to unmarshall
+   */
+  public Comment(Entity entity) {
+    entityUnMarshall(entity);
   }
 
   /** Getter and setter for commentText */
@@ -76,5 +87,38 @@ public class Comment {
   /** Deletes the comment's sentiment score */
   public void deleteSentimentScore() {
     sentimentScoreFlag = false;
+  }
+
+  /**
+   * Marshalls the current class instance into a Datastore entity.
+   *
+   * @param entity the entity to marshall data into.
+   */
+  public void entityMarshall(Entity entity) {
+    entity.setProperty("text", commentText);
+    if (sentimentScoreFlag) {
+      entity.setProperty("sentiment-score", sentimentScore);
+    } else {
+      entity.removeProperty("sentiment-score");
+    }
+  }
+
+  /**
+   * Unmarshalls the provided Datastore entity into this class instance, overwriting the instance's
+   * current fields.
+   *
+   * @param entity the entity to unmarshall data from.
+   */
+  public void entityUnMarshall(Entity entity) {
+    commentText = (String) entity.getProperty("text");
+    if (entity.hasProperty("sentiment-score")) {
+      sentimentScoreFlag = true;
+      // These few lines are the result of a float being converted
+      // to a Double object by Datastore
+      Double score = (Double) entity.getProperty("sentiment-score");
+      sentimentScore = score.floatValue();
+    } else {
+      sentimentScoreFlag = false;
+    }
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -20,7 +20,11 @@ import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
+import com.google.cloud.language.v1.Document;
+import com.google.cloud.language.v1.LanguageServiceClient;
+import com.google.cloud.language.v1.Sentiment;
 import com.google.gson.Gson;
+import com.google.sps.data.Comment;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -66,13 +70,22 @@ public class DataServlet extends HttpServlet {
     }
 
     // Gets all existing comments from database
-    List<String> commentsList = new ArrayList<String>();
+    List<Comment> commentsList = new ArrayList<Comment>();
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
     Query query = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
     PreparedQuery results = datastore.prepare(query);
     for (Entity entity : results.asIterable()) {
-      commentsList.add(entity.getProperty("text").toString());
+      String commentText = (String) entity.getProperty("text");
+      Comment el = new Comment(commentText);
+      if (entity.hasProperty("sentiment-score")) {
+        // This ugliness is because for some reason, the object I store
+        // in datastore is converted to a Double object. This code
+        // performs the conversion Double -> double -> float.
+        double score = (Double) entity.getProperty("sentiment-score");
+        el.setSentimentScore((float) score);
+      }
+      commentsList.add(el);
     }
 
     // If max-comments was provided, extract a sublist.
@@ -97,13 +110,16 @@ public class DataServlet extends HttpServlet {
    */
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    // Constructs comment and gets comment sentiment
     String commentText = getParameter(request, "comment-text", "");
+    float commentSentiment = getSentiment(commentText);
 
     // Create entity
     long timestamp = System.currentTimeMillis();
     Entity commentEntity = new Entity("Comment");
     commentEntity.setProperty("timestamp", timestamp);
     commentEntity.setProperty("text", commentText);
+    commentEntity.setProperty("sentiment-score", commentSentiment);
 
     // Add to database
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
@@ -111,6 +127,24 @@ public class DataServlet extends HttpServlet {
 
     response.setContentType("application/json;");
     response.getWriter().println("{ \"status\": \"ok\" }");
+  }
+
+  /**
+   * Attains the sentiment of the comment string according to Google Cloud Natural Language
+   * sentiment analysis. The sentiment is graded on a one-dimensional scale of positive or negative,
+   * with -1.0 = negative and 1.0 = positive.
+   *
+   * @param comment The comment to analyze
+   * @return A sentiment score in the interval [-1.0, 1.0]
+   */
+  private float getSentiment(String comment) throws IOException {
+    Document doc =
+        Document.newBuilder().setContent(comment).setType(Document.Type.PLAIN_TEXT).build();
+    LanguageServiceClient languageService = LanguageServiceClient.create();
+    Sentiment sentiment = languageService.analyzeSentiment(doc).getDocumentSentiment();
+    float score = sentiment.getScore();
+    languageService.close();
+    return score;
   }
 
   /**

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -23,7 +23,6 @@ import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 import javax.servlet.annotation.WebServlet;
@@ -36,14 +35,6 @@ import javax.servlet.http.HttpServletResponse;
 public class DataServlet extends HttpServlet {
 
   static final long serialVersionUID = 1L;
-
-  /** Comments to be sent out upon /data GET request. */
-  private ArrayList<String> commentsList =
-      new ArrayList<String>(
-          Arrays.asList(
-              "This is a normal comment",
-              "This is another normal comment",
-              "This is yet a third comment"));
 
   /**
    * Processes HTTP GET requests for the /data servlet The requests are responded to by a list of
@@ -118,7 +109,8 @@ public class DataServlet extends HttpServlet {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     datastore.put(commentEntity);
 
-    response.sendRedirect("/com.html");
+    response.setContentType("application/json;");
+    response.getWriter().println("{ \"status\": \"ok\" }");
   }
 
   /**

--- a/portfolio/src/main/webapp/src/com.html
+++ b/portfolio/src/main/webapp/src/com.html
@@ -10,17 +10,13 @@
     <div id="header"></div>
     <div id="contents">
       <h1>Comments</h1>
-      <form action="/data" method="POST" class="port-card" id="comment-entry">
+      <div class="port-card" id="comment-entry">
         <div class="port-card-title">Please enter your comment here</div>
         <label class="port-text-field">
-          <input
-            name="comment-text"
-            class="port-text-field-input"
-            id="comment-text"
-          />
+          <input class="port-text-field-input" id="comment-text" />
         </label>
         <div class="port-card-actions">
-          <button type="button" class="port-card-button" id="comment-delete">
+          <button class="port-card-button" id="comment-delete">
             <span class="port-card-button-label">
               Delete Comments
             </span>
@@ -37,13 +33,13 @@
               <option value="">All</option>
             </select>
           </div>
-          <button type="submit" class="port-card-button" id="comment-submit">
+          <button class="port-card-button" id="comment-submit">
             <span class="port-card-button-label">
               Submit Comment
             </span>
           </button>
         </div>
-      </form>
+      </div>
       <div id="comment-list"></div>
     </div>
     <div id="links"></div>

--- a/portfolio/src/main/webapp/src/com.js
+++ b/portfolio/src/main/webapp/src/com.js
@@ -70,6 +70,37 @@ function getCommentsFromServer(maxComments) {
 }
 
 /**
+ * Adds comment data to the server by submitting a POST
+ * request to /data. commentText contains the string that
+ * will be stored in the comment. Returns a promise with
+ * an undefined value on success.
+ *
+ * @param {String} commentText
+ * @return {Promise<any>}
+ */
+function submitCommentToServer(commentText) {
+  // Package POST arguments
+  const args = new URLSearchParams();
+  args.append('comment-text', commentText);
+  // Submit POST request
+  return fetch('/data', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: args,
+  }).then((response) => {
+    if (response.ok) {
+      return response.json();
+    } else {
+      return Promise.reject(
+        new Error(response.status + ': ' + response.statusText),
+      );
+    }
+  });
+}
+
+/**
  * Deletes all comments data from server by submitting a
  * GET request to /delete-data. Returns a promise with
  * an undefined value on success.
@@ -116,7 +147,6 @@ function createCommentCard(commentText) {
  */
 function addCommentsToPage(comments) {
   // Clear existing HTML
-  console.log(comments);
   document.getElementById('comment-list').innerHTML = '';
   comments.forEach((comment) => {
     const newCard = createCommentCard(comment);
@@ -147,6 +177,25 @@ function updateComments() {
 }
 
 /**
+ * Adds a comment to the server, taking text from the input
+ * form.
+ *
+ */
+function addComment() {
+  const commentText = document.getElementById('comment-text').value;
+  submitCommentToServer(commentText)
+    .then((_) => updateComments())
+    .catch((error) => {
+      const errorCard = createCommentCard(
+        '<b>Unable to add comment to server</b>',
+      );
+      document.getElementById('comment-list').innerHTML = '';
+      document.getElementById('comment-list').appendChild(errorCard);
+      console.error(error);
+    });
+}
+
+/**
  * Deletes all comments from the server and reloads the page
  *
  */
@@ -167,6 +216,16 @@ function deleteAllComments() {
 document
   .getElementById('comment-delete')
   .addEventListener('click', deleteAllComments);
+
+document.getElementById('comment-submit').addEventListener('click', addComment);
+
+/** Add 'enter' keystroke listener to comment input field */
+document.getElementById('comment-text').addEventListener('keyup', (event) => {
+  if (event.key === 'Enter') {
+    addComment();
+  }
+});
+
 /** Change in number of comments displayed per page */
 document
   .getElementById('comment-number')

--- a/portfolio/src/main/webapp/src/com.scss
+++ b/portfolio/src/main/webapp/src/com.scss
@@ -54,6 +54,10 @@
   @extend .mdc-card__actions;
 }
 
+.port-card-action-right {
+  margin-left: auto;
+}
+
 .port-card-button {
   @extend .mdc-button;
   @extend .mdc-card__action;


### PR DESCRIPTION
In this pull request, I add comment sentiment analysis -- the extent of comment positivity or negativity is represented by emojis.

Features Added:
- Cloud Natural Language Sentiment analysis for submitted comments
- Sentiment storage in Datastore.
- Display of sentiment as emoji

Again, the app is deployed on https://codyjrivera-step-2020.uc.r.appspot.com/com.html
A screenshot is below:
 
![image](https://user-images.githubusercontent.com/42156440/84435758-f4c45200-abf7-11ea-8a2a-bb15dd7ecd95.png)
