### PR TITLE
Amend scheduler to account for optional attendees.

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -232,6 +232,7 @@ public final class FindMeetingQuery {
     // Temporary range
     private int startTime;
     private int endTime;
+    // Whether there is a temporary range that is currently being built
     private boolean flag;
 
     /** Makes a new FlatRangeSetBuilder */

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -60,9 +60,7 @@ public final class FindMeetingQuery {
 
     List<TimeRange> conflictSet = cleanConflictSet(rawConflictSet.values());
     List<TimeRange> optionalConflictSet = cleanConflictSet(rawOptionalConflictSet.values());
-    //System.out.println(optionalConflictSet);    
     List<TimeRange> combinedConflictSet = combineConflictSets(conflictSet, optionalConflictSet);
-    //System.out.println(combinedConflictSet);    
 
     Collection<TimeRange> combinedValidTimes = getValidTimes(combinedConflictSet, request.getDuration());
     if (!combinedValidTimes.isEmpty()) {
@@ -237,7 +235,7 @@ public final class FindMeetingQuery {
         rawRange = setA.get(indexA);
         ++indexA;
       } else {
-        rawRange = setA.get(indexB);
+        rawRange = setB.get(indexB);
         ++indexB;
       }
 

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -14,11 +14,10 @@
 
 package com.google.sps;
 
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.SortedMap;
@@ -30,8 +29,8 @@ import java.util.TreeMap;
  * scheduled on a day. The algorithm returns a collection of time intervals at least as long as the
  * requested meeting time.
  *
- * <p>This algorithm generates time intervals in which ALL mandatory attendees are free and, if 
- * such a valid interval exists, intervals in which all optional attendees are free as well.
+ * <p>This algorithm generates time intervals in which ALL mandatory attendees are free and, if such
+ * a valid interval exists, intervals in which all optional attendees are free as well.
  *
  * <p>This algorithm's *expected* runtime is O(M + E log E), where M = the number of mandatory
  * attendees and E = the number of events and each of their attendees.
@@ -56,13 +55,15 @@ public final class FindMeetingQuery {
     // Expected O(E log E) time
     SortedMap<Integer, TimeRange> rawConflictSet = new TreeMap<Integer, TimeRange>();
     SortedMap<Integer, TimeRange> rawOptionalConflictSet = new TreeMap<Integer, TimeRange>();
-    generateRawConflictSet(rawConflictSet, rawOptionalConflictSet, events, requestedAttendees, optionalAttendees);
+    generateRawConflictSet(
+        rawConflictSet, rawOptionalConflictSet, events, requestedAttendees, optionalAttendees);
 
     List<TimeRange> conflictSet = cleanConflictSet(rawConflictSet.values());
     List<TimeRange> optionalConflictSet = cleanConflictSet(rawOptionalConflictSet.values());
     List<TimeRange> combinedConflictSet = combineConflictSets(conflictSet, optionalConflictSet);
 
-    Collection<TimeRange> combinedValidTimes = getValidTimes(combinedConflictSet, request.getDuration());
+    Collection<TimeRange> combinedValidTimes =
+        getValidTimes(combinedConflictSet, request.getDuration());
     if (!combinedValidTimes.isEmpty()) {
       return combinedValidTimes;
     }
@@ -98,35 +99,35 @@ public final class FindMeetingQuery {
    * entries. Thus, the second phase, done outside of the loop, converts the raw set in O(n) time
    * into a set without overlapping entries.
    *
-   * <p> To incorporate optional attendees, I duplicate operations (1) and (2) for optional attendees,
-   * storing the results in another set and cleaning that set separately. I then create another cleaned
-   * set that is the combination of the mandatory and optional attendees' conflict sets. If there is
-   * a set of times that works for all attendees, then those times are returned, otherwise, only mandatory
-   * attendees are considered. Asymptotic runtime does not change, as the extra work can be absorbed
-   * by a constant factor.
+   * <p>To incorporate optional attendees, I duplicate operations (1) and (2) for optional
+   * attendees, storing the results in another set and cleaning that set separately. I then create
+   * another cleaned set that is the combination of the mandatory and optional attendees' conflict
+   * sets. If there is a set of times that works for all attendees, then those times are returned,
+   * otherwise, only mandatory attendees are considered. Asymptotic runtime does not change, as the
+   * extra work can be absorbed by a constant factor.
    */
 
   /**
    * Generates a set of time ranges that conflict with any of the requested attendees' schedules.
-   * Note that ranges may overlap. Expected runtime is O(E log E). Sets are represented as
-   * a SortedMap with start time as the key and TimeRange as the value.
+   * Note that ranges may overlap. Expected runtime is O(E log E). Sets are represented as a
+   * SortedMap with start time as the key and TimeRange as the value.
    *
-   * @param rawConflictSet Overlapping set of all 
+   * @param rawConflictSet Overlapping set of all
    * @param events the collection of all events
    * @param requestedAttendees the set of all requested attendees.
    */
   private void generateRawConflictSet(
       SortedMap<Integer, TimeRange> rawConflictSet,
       SortedMap<Integer, TimeRange> rawOptionalConflictSet,
-      Collection<Event> events, 
+      Collection<Event> events,
       Set<String> requestedAttendees,
       Set<String> optionalAttendees) {
     for (Event event : events) {
       if (attendeesIntersect(event.getAttendees(), requestedAttendees)) {
         insertTimeRange(rawConflictSet, event.getWhen());
-      } 
+      }
       if (attendeesIntersect(event.getAttendees(), optionalAttendees)) {
-        insertTimeRange(rawOptionalConflictSet, event.getWhen());  
+        insertTimeRange(rawOptionalConflictSet, event.getWhen());
       }
     }
   }
@@ -150,8 +151,7 @@ public final class FindMeetingQuery {
   }
 
   /**
-   * Inserts a time range into a SortedMap containing an ordered overlapping set
-   * of times.
+   * Inserts a time range into a SortedMap containing an ordered overlapping set of times.
    *
    * @param rawSet The set of times
    * @param timeRange The range to insert
@@ -163,7 +163,7 @@ public final class FindMeetingQuery {
       TimeRange setTime = rawSet.get(timeRange.start());
       if (timeRange.duration() > setTime.duration()) {
         rawSet.put(timeRange.start(), timeRange);
-      } 
+      }
     } else {
       rawSet.put(timeRange.start(), timeRange);
     }
@@ -188,8 +188,8 @@ public final class FindMeetingQuery {
   }
 
   /**
-   * Combines two existing sorted and cleaned conflict sets. This is basically
-   * merging with extra considerations for end times. Runtime O(E).
+   * Combines two existing sorted and cleaned conflict sets. This is basically merging with extra
+   * considerations for end times. Runtime O(E).
    *
    * @param setA the first conflict set
    * @param setB the second conflict set
@@ -226,11 +226,7 @@ public final class FindMeetingQuery {
     return builder.getFlatRangeSet();
   }
 
-  /**
-   * Builds a flattened range set, where none of the
-   * elements overlap.
-   *
-   */
+  /** Builds a flattened range set, where none of the elements overlap. */
   private class FlatRangeSetBuilder {
     private List<TimeRange> rangeSet;
     // Temporary range
@@ -238,9 +234,7 @@ public final class FindMeetingQuery {
     private int endTime;
     private boolean flag;
 
-    /**
-     * Makes a new FlatRangeSetBuilder
-     */
+    /** Makes a new FlatRangeSetBuilder */
     FlatRangeSetBuilder() {
       rangeSet = new ArrayList<TimeRange>();
       startTime = 0;
@@ -276,8 +270,8 @@ public final class FindMeetingQuery {
     }
 
     /**
-     * Returns the non-overlapping range set as a list of time ranges.
-     * Behavior after calling this method is undefined.
+     * Returns the non-overlapping range set as a list of time ranges. Behavior after calling this
+     * method is undefined.
      *
      * @return non-overlapping range set
      */
@@ -288,7 +282,6 @@ public final class FindMeetingQuery {
       return rangeSet;
     }
   }
-
 
   /**
    * Converts a set of conflicting time intervals into a set of good time intervals that are at

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -14,9 +14,11 @@
 
 package com.google.sps;
 
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.SortedMap;
@@ -28,8 +30,8 @@ import java.util.TreeMap;
  * scheduled on a day. The algorithm returns a collection of time intervals at least as long as the
  * requested meeting time.
  *
- * <p>Right now, this algorithm only generates time intervals in which ALL mandatory attendees are
- * free.
+ * <p>This algorithm generates time intervals in which ALL mandatory attendees are free and, if 
+ * such a valid interval exists, intervals in which all optional attendees are free as well.
  *
  * <p>This algorithm's *expected* runtime is O(M + E log E), where M = the number of mandatory
  * attendees and E = the number of events and each of their attendees.
@@ -49,11 +51,29 @@ public final class FindMeetingQuery {
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
     // Expected O(M) time
     Set<String> requestedAttendees = new HashSet<String>(request.getAttendees());
+    Set<String> optionalAttendees = new HashSet<String>(request.getOptionalAttendees());
 
     // Expected O(E log E) time
-    SortedMap<Integer, TimeRange> rawConflictSet =
-        generateRawConflictSet(events, requestedAttendees);
-    Collection<TimeRange> conflictSet = cleanConflictSet(rawConflictSet.values());
+    SortedMap<Integer, TimeRange> rawConflictSet = new TreeMap<Integer, TimeRange>();
+    SortedMap<Integer, TimeRange> rawOptionalConflictSet = new TreeMap<Integer, TimeRange>();
+    generateRawConflictSet(rawConflictSet, rawOptionalConflictSet, events, requestedAttendees, optionalAttendees);
+
+    List<TimeRange> conflictSet = cleanConflictSet(rawConflictSet.values());
+    List<TimeRange> optionalConflictSet = cleanConflictSet(rawOptionalConflictSet.values());
+    //System.out.println(optionalConflictSet);    
+    List<TimeRange> combinedConflictSet = combineConflictSets(conflictSet, optionalConflictSet);
+    //System.out.println(combinedConflictSet);    
+
+    Collection<TimeRange> combinedValidTimes = getValidTimes(combinedConflictSet, request.getDuration());
+    if (!combinedValidTimes.isEmpty()) {
+      return combinedValidTimes;
+    }
+    // Edge case -- if all optional attendees cannot meet
+    // and there are no mandatory attendees, we return no times, according to
+    // the test optionalOnlyNoGaps
+    if (request.getAttendees().isEmpty()) {
+      return Arrays.asList();
+    }
     return getValidTimes(conflictSet, request.getDuration());
   }
 
@@ -79,35 +99,38 @@ public final class FindMeetingQuery {
    * with O(log n) insertion time. The first phase returns a set which may have several overlapping
    * entries. Thus, the second phase, done outside of the loop, converts the raw set in O(n) time
    * into a set without overlapping entries.
+   *
+   * <p> To incorporate optional attendees, I duplicate operations (1) and (2) for optional attendees,
+   * storing the results in another set and cleaning that set separately. I then create another cleaned
+   * set that is the combination of the mandatory and optional attendees' conflict sets. If there is
+   * a set of times that works for all attendees, then those times are returned, otherwise, only mandatory
+   * attendees are considered. Asymptotic runtime does not change, as the extra work can be absorbed
+   * by a constant factor.
    */
 
   /**
    * Generates a set of time ranges that conflict with any of the requested attendees' schedules.
-   * Note that ranges may overlap. Expected runtime is O(E log E).
+   * Note that ranges may overlap. Expected runtime is O(E log E). Sets are represented as
+   * a SortedMap with start time as the key and TimeRange as the value.
    *
+   * @param rawConflictSet Overlapping set of all 
    * @param events the collection of all events
    * @param requestedAttendees the set of all requested attendees.
-   * @return a map of potentially overlapping time ranges, with the start time as the key
    */
-  private SortedMap<Integer, TimeRange> generateRawConflictSet(
-      Collection<Event> events, Set<String> requestedAttendees) {
-    SortedMap<Integer, TimeRange> rawConflictSet = new TreeMap<Integer, TimeRange>();
+  private void generateRawConflictSet(
+      SortedMap<Integer, TimeRange> rawConflictSet,
+      SortedMap<Integer, TimeRange> rawOptionalConflictSet,
+      Collection<Event> events, 
+      Set<String> requestedAttendees,
+      Set<String> optionalAttendees) {
     for (Event event : events) {
       if (attendeesIntersect(event.getAttendees(), requestedAttendees)) {
-        TimeRange eventTime = event.getWhen();
-        if (rawConflictSet.containsKey(eventTime.start())) {
-          // If an event with the same start time is in the set,
-          // keep the longest event
-          TimeRange setTime = rawConflictSet.get(eventTime.start());
-          if (eventTime.duration() > setTime.duration()) {
-            rawConflictSet.put(eventTime.start(), eventTime);
-          }
-        } else {
-          rawConflictSet.put(eventTime.start(), eventTime);
-        }
+        insertTimeRange(rawConflictSet, event.getWhen());
+      } 
+      if (attendeesIntersect(event.getAttendees(), optionalAttendees)) {
+        insertTimeRange(rawOptionalConflictSet, event.getWhen());  
       }
     }
-    return rawConflictSet;
   }
 
   /**
@@ -129,13 +152,33 @@ public final class FindMeetingQuery {
   }
 
   /**
+   * Inserts a time range into a SortedMap containing an ordered overlapping set
+   * of times.
+   *
+   * @param rawSet The set of times
+   * @param timeRange The range to insert
+   */
+  private void insertTimeRange(SortedMap<Integer, TimeRange> rawSet, TimeRange timeRange) {
+    if (rawSet.containsKey(timeRange.start())) {
+      // If an event with the same start time is in the set,
+      // keep the longest event
+      TimeRange setTime = rawSet.get(timeRange.start());
+      if (timeRange.duration() > setTime.duration()) {
+        rawSet.put(timeRange.start(), timeRange);
+      } 
+    } else {
+      rawSet.put(timeRange.start(), timeRange);
+    }
+  }
+
+  /**
    * Converts a conflict set which may contain overlapping intervals into one that contains none.
    * Maximum runtime O(E).
    *
    * @param rawConflictSet
    * @return an ordered conflict set with no overlapping invervals.
    */
-  private Collection<TimeRange> cleanConflictSet(Collection<TimeRange> rawConflictSet) {
+  private List<TimeRange> cleanConflictSet(Collection<TimeRange> rawConflictSet) {
     List<TimeRange> conflictSet = new ArrayList<TimeRange>();
     // Temporary TimeRange construction information
     boolean tempRangeFlag = false;
@@ -168,6 +211,112 @@ public final class FindMeetingQuery {
       conflictSet.add(TimeRange.fromStartEnd(startTime, endTime, false));
     }
     return conflictSet;
+  }
+
+  /**
+   * Combines two existing sorted and cleaned conflict sets. This is basically
+   * merging with extra considerations for end times. Runtime O(E).
+   *
+   * @param setA the first conflict set
+   * @param setB the second conflict set
+   * @return the union of the two conflict sets
+   */
+  public List<TimeRange> combineConflictSets(List<TimeRange> setA, List<TimeRange> setB) {
+    List<TimeRange> combinedConflictSet = new ArrayList<TimeRange>();
+    // Temporary TimeRange construction information
+    boolean tempRangeFlag = false;
+    int startTime = 0, endTime = 0;
+
+    int indexA = 0, indexB = 0;
+
+    // Merge and deal with any overlapping intervals.
+    // TODO -- Refactor so there is not so much repeated code.
+    while (indexA < setA.size() && indexB < setB.size()) {
+      TimeRange rawRange = null;
+      if (setA.get(indexA).start() <= setB.get(indexB).start()) {
+        rawRange = setA.get(indexA);
+        ++indexA;
+      } else {
+        rawRange = setA.get(indexB);
+        ++indexB;
+      }
+
+      if (!tempRangeFlag) {
+        // Start temporary time range with RawRange
+        tempRangeFlag = true;
+        startTime = rawRange.start();
+        endTime = rawRange.end();
+      } else {
+        if (rawRange.start() < endTime) {
+          // Temporary time range := UNION(temporary time range, RawRange)
+          // Because both inputs are sorted, we do not need to consider
+          // the case where rawRange.start() < startTime.
+          endTime = Integer.max(rawRange.end(), endTime);
+        } else {
+          // Add temporary time range
+          combinedConflictSet.add(TimeRange.fromStartEnd(startTime, endTime, false));
+          // Start another temporary time range
+          startTime = rawRange.start();
+          endTime = rawRange.end();
+        }
+      }
+    }
+
+    while (indexA < setA.size()) {
+      TimeRange rawRange = setA.get(indexA);
+      ++indexA;
+
+      if (!tempRangeFlag) {
+        // Start temporary time range with RawRange
+        tempRangeFlag = true;
+        startTime = rawRange.start();
+        endTime = rawRange.end();
+      } else {
+        if (rawRange.start() < endTime) {
+          // Temporary time range := UNION(temporary time range, RawRange)
+          // Because both inputs are sorted, we do not need to consider
+          // the case where rawRange.start() < startTime.
+          endTime = Integer.max(rawRange.end(), endTime);
+        } else {
+          // Add temporary time range
+          combinedConflictSet.add(TimeRange.fromStartEnd(startTime, endTime, false));
+          // Start another temporary time range
+          startTime = rawRange.start();
+          endTime = rawRange.end();
+        }
+      }
+    }
+
+    while (indexB < setB.size()) {
+      TimeRange rawRange = setB.get(indexB);
+      ++indexB;
+
+      if (!tempRangeFlag) {
+        // Start temporary time range with RawRange
+        tempRangeFlag = true;
+        startTime = rawRange.start();
+        endTime = rawRange.end();
+      } else {
+        if (rawRange.start() < endTime) {
+          // Temporary time range := UNION(temporary time range, RawRange)
+          // Because both inputs are sorted, we do not need to consider
+          // the case where rawRange.start() < startTime.
+          endTime = Integer.max(rawRange.end(), endTime);
+        } else {
+          // Add temporary time range
+          combinedConflictSet.add(TimeRange.fromStartEnd(startTime, endTime, false));
+          // Start another temporary time range
+          startTime = rawRange.start();
+          endTime = rawRange.end();
+        }
+      }
+    }
+
+    if (tempRangeFlag) {
+      combinedConflictSet.add(TimeRange.fromStartEnd(startTime, endTime, false));
+    }
+
+    return combinedConflictSet;
   }
 
   /**

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -32,6 +32,7 @@ public final class FindMeetingQueryTest {
   // Some people that we can use in our tests.
   private static final String PERSON_A = "Person A";
   private static final String PERSON_B = "Person B";
+  private static final String PERSON_C = "Person C";
 
   // All dates are the first day of the year 2020.
   private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
@@ -41,6 +42,7 @@ public final class FindMeetingQueryTest {
   private static final int TIME_1000AM = TimeRange.getTimeInMinutes(10, 0);
   private static final int TIME_1100AM = TimeRange.getTimeInMinutes(11, 00);
 
+  private static final int DURATION_15_MINUTES = 15;
   private static final int DURATION_30_MINUTES = 30;
   private static final int DURATION_60_MINUTES = 60;
   private static final int DURATION_90_MINUTES = 90;
@@ -308,6 +310,191 @@ public final class FindMeetingQueryTest {
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected = Arrays.asList();
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  /** 
+   * Tests for optional attendees, where the choice is either
+   * to include all of them or none of them.
+   */
+
+  @Test
+  public void optionalAttendeeAllDay() {
+    // Based on everyAttendeeIsConsidered, but there is an optional person C with
+    // an all-day event. This attendee should be ignored.
+    //
+    // Events  : |------------C (Opt)----------|
+    //                 |--A--|     |--B--|
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
+    Collection<Event> events =
+        Arrays.asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_B)),
+            new Event(
+                "Event 3",
+                TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TimeRange.END_OF_DAY, true),
+                Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalAttendeeMorning() {
+    // Based on everyAttendeeIsConsidered, but there is an optional person C with
+    // a event from 8:30AM to 9:00AM.
+    //
+    // Events  :             |-C(O)|
+    //                 |--A--|     |--B--|
+    // Day     : |-----------------------------|
+    // Options : |--1--|                 |--2--|
+    Collection<Event> events =
+        Arrays.asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_B)),
+            new Event(
+                "Event 3",
+                TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void justEnoughRoomOptional() {
+    // Have a required and an optional attendee, but return
+    // only the required attendee's free time as including the
+    // optional attendee would result in a time insufficiently
+    // long.
+    //
+    // Events  : |--A--|     |----A----|
+    //                 |B-O|
+    // Day     : |---------------------|
+    // Options :       |-----|
+    Collection<Event> events =
+        Arrays.asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 3",
+                TimeRange.fromStartDuration(TIME_0830AM, DURATION_15_MINUTES),
+                Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+      Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalOnlyGaps() {
+    // Have two optional attendees with several gaps in their schedule.
+    // Should return the gaps.
+    //
+    // Events   : |---A---|     |--B--|     |--A---|
+    // Day      : |--------------------------------|
+    // Options  :         |-----|     |-----|
+    Collection<Event> events =
+      Arrays.asList(
+        new Event(
+          "Event 1",
+          TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+          Arrays.asList(PERSON_A)),
+        new Event(
+          "Event 2",
+          TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+          Arrays.asList(PERSON_B)),
+        new Event(
+          "Event 3",
+          TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true),
+          Arrays.asList(PERSON_A))); 
+    
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+      Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
+                    TimeRange.fromStartDuration(TIME_0930AM, DURATION_30_MINUTES));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalOnlyNoGaps() {
+    // Have two optional attendees with no gaps in their schedule.
+    // Should return no options
+    //
+    // Events   : |---A---------|--B--|--------A---|
+    // Day      : |--------------------------------|
+    // Options  : 
+    Collection<Event> events =
+      Arrays.asList(
+        new Event(
+          "Event 1",
+          TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0900AM, false),
+          Arrays.asList(PERSON_A)),
+        new Event(
+          "Event 2",
+          TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+          Arrays.asList(PERSON_B)),
+        new Event(
+          "Event 3",
+          TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true),
+          Arrays.asList(PERSON_A))); 
+    
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+      Arrays.asList();
 
     Assert.assertEquals(expected, actual);
   }

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -318,7 +318,7 @@ public final class FindMeetingQueryTest {
    * Tests for optional attendees, where the choice is either
    * to include all of them or none of them.
    */
-
+  
   @Test
   public void optionalAttendeeAllDay() {
     // Based on everyAttendeeIsConsidered, but there is an optional person C with

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -314,11 +314,10 @@ public final class FindMeetingQueryTest {
     Assert.assertEquals(expected, actual);
   }
 
-  /** 
-   * Tests for optional attendees, where the choice is either
-   * to include all of them or none of them.
+  /**
+   * Tests for optional attendees, where the choice is either to include all of them or none of
+   * them.
    */
-  
   @Test
   public void optionalAttendeeAllDay() {
     // Based on everyAttendeeIsConsidered, but there is an optional person C with
@@ -425,7 +424,7 @@ public final class FindMeetingQueryTest {
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-      Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+        Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
 
     Assert.assertEquals(expected, actual);
   }
@@ -439,28 +438,29 @@ public final class FindMeetingQueryTest {
     // Day      : |--------------------------------|
     // Options  :         |-----|     |-----|
     Collection<Event> events =
-      Arrays.asList(
-        new Event(
-          "Event 1",
-          TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-          Arrays.asList(PERSON_A)),
-        new Event(
-          "Event 2",
-          TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
-          Arrays.asList(PERSON_B)),
-        new Event(
-          "Event 3",
-          TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true),
-          Arrays.asList(PERSON_A))); 
-    
+        Arrays.asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_B)),
+            new Event(
+                "Event 3",
+                TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true),
+                Arrays.asList(PERSON_A)));
+
     MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
     request.addOptionalAttendee(PERSON_A);
     request.addOptionalAttendee(PERSON_B);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-      Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
-                    TimeRange.fromStartDuration(TIME_0930AM, DURATION_30_MINUTES));
+        Arrays.asList(
+            TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
+            TimeRange.fromStartDuration(TIME_0930AM, DURATION_30_MINUTES));
 
     Assert.assertEquals(expected, actual);
   }
@@ -472,29 +472,28 @@ public final class FindMeetingQueryTest {
     //
     // Events   : |---A---------|--B--|--------A---|
     // Day      : |--------------------------------|
-    // Options  : 
+    // Options  :
     Collection<Event> events =
-      Arrays.asList(
-        new Event(
-          "Event 1",
-          TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0900AM, false),
-          Arrays.asList(PERSON_A)),
-        new Event(
-          "Event 2",
-          TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
-          Arrays.asList(PERSON_B)),
-        new Event(
-          "Event 3",
-          TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true),
-          Arrays.asList(PERSON_A))); 
-    
+        Arrays.asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0900AM, false),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_B)),
+            new Event(
+                "Event 3",
+                TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true),
+                Arrays.asList(PERSON_A)));
+
     MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
     request.addOptionalAttendee(PERSON_A);
     request.addOptionalAttendee(PERSON_B);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected =
-      Arrays.asList();
+    Collection<TimeRange> expected = Arrays.asList();
 
     Assert.assertEquals(expected, actual);
   }


### PR DESCRIPTION
In this PR, I add tests for and implement a feature that allows optional attendees to be considered by the scheduling algorithm. My algorithm as implemented passes every test, and has the same time complexity as the previous algorithm.

Again, I have not deployed anything, but you can run tests and a webpage using
```
mvn package appengine:deploy
```